### PR TITLE
[RDY] Pocketball pseudo scientific description

### DIFF
--- a/items/tool.json
+++ b/items/tool.json
@@ -3,7 +3,7 @@
     "id": "pokeball",
     "type": "TOOL",
     "name": "pocket ball creature warp container",
-    "description": "Creature holding container in form of ball based on experimental warp packing technology. Allows to safely transport creatures but seems to conserve weight, making its use impractical. Someone may misleadingly reference it as Pockeball.",
+    "description": "Creature holding container in form of ball based on experimental warp packing technology. Allows to safely transport creatures but seems to conserve weight, making its use impractical. Someone may misleadingly reference it as Pokeball.",
     "weight": 300,
     "volume": 3,
     "price": 2000000,

--- a/items/tool.json
+++ b/items/tool.json
@@ -2,8 +2,8 @@
   {
     "id": "pokeball",
     "type": "TOOL",
-    "name": "pocket ball",
-    "description": "A fist-sized ball that holds the ...erm, 'energy' of a monster, allowing you to transport them within safely.  Seems to conserve weight, making its use impractical.",
+    "name": "pocket ball creature warp container",
+    "description": "Creature holding container in form of ball based on experimental warp packing technology. Allows to safely transport creatures but seems to conserve weight, making its use impractical. Someone may misleadingly reference it as Pockeball.",
     "weight": 300,
     "volume": 3,
     "price": 2000000,


### PR DESCRIPTION
Changed pockeball descriptoin to be closer to "scientific" description. Now there is no "strange energy" or "erm".
Reasons to change:
* PRM does not add magic.
* PRM does not add grossly to the sci-fi theme of the game.
* PRM does not try to break lore.

Previous description refers it exacltly as Pokeball  from Pokemon universe. And have no meaning description related to the game LORE.
Now it is releates to portal experiments and it is still recognizable reference to the Pokemon Universe.