### PR TITLE
Changes filter mask warmth to original value

### DIFF
--- a/items/armor_override.json
+++ b/items/armor_override.json
@@ -690,7 +690,7 @@
     "covers": [ "MOUTH" ],
     "coverage": 100,
     "encumbrance": 20,
-    "warmth": 20,
+    "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 7
   }


### PR DESCRIPTION
Changes the warmth of filter masks from 20, to 15. This is consistent with the warmth that filter masks had prior to the pull request that reduces it to 10 in the base game, rather than becoming 5 warmth *higher* than it was originally.

The restores original functionality of having filter masks give the exact same warmth as non-winter survivor masks.

Closes https://github.com/pisskop/PKs_Rebalancing/issues/17