### PR TITLE
Implements use of copy-from for overmap edits

### DIFF
--- a/pk_overmap.json
+++ b/pk_overmap.json
@@ -601,8 +601,9 @@
     "city_distance": [0, -1],
     "occurrences": [3, 15]
   },{
-     "type": "overmap_special",
-     "id": "bog",
+    "type": "overmap_special",
+    "id": "bog",
+    "copy-from" : "bog",
     "city_distance": [0, -1],
     "occurrences": [0, 2]
   },{

--- a/pk_overmap.json
+++ b/pk_overmap.json
@@ -20,17 +20,6 @@
     "flags": [ "CLASSIC" ]
   },{
     "type": "overmap_special",
-    "id": "Swamp Shack",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "hunter_shack"}
-    ],
-    "locations": [ "swamp" ],
-    "city_distance": [12, -1],
-    "city_sizes": [4, 16],
-    "occurrences": [0, 8],
-    "flags": [ "CLASSIC" ]
-  },{
-    "type": "overmap_special",
     "id": "old barn",
     "overmaps": [
       { "point":[0,0,0], "overmap": "barn_old"}
@@ -63,39 +52,8 @@
     "flags": [ "CLASSIC" ]
   },{
     "type": "overmap_special",
-    "id": "Prison",
-    "overmaps": [
-      { "point":[-1,0,0], "overmap": "prison_3"},
-      { "point":[0,0,0], "overmap": "prison_2"},
-      { "point":[1,0,0], "overmap": "prison_1"},
-      { "point":[-1,1,0], "overmap": "prison_6"},
-      { "point":[0,1,0], "overmap": "prison_5"},
-      { "point":[1,1,0], "overmap": "prison_4"},
-      { "point":[-1,2,0], "overmap": "prison_9"},
-      { "point":[0,2,0], "overmap": "prison_8"},
-      { "point":[1,2,0], "overmap": "prison_7"},
-      { "point":[-1,0,-1], "overmap": "prison_b"},
-      { "point":[0,0,-1], "overmap": "prison_b_entrance"},
-      { "point":[1,0,-1], "overmap": "prison_b"},
-      { "point":[-1,1,-1], "overmap": "prison_b"},
-      { "point":[0,1,-1], "overmap": "prison_b"},
-      { "point":[1,1,-1], "overmap": "prison_b"},
-      { "point":[-1,2,-1], "overmap": "prison_b"},
-      { "point":[0,2,-1], "overmap": "prison_b"},
-      { "point":[1,2,-1], "overmap": "prison_b"}
-    ],
-    "connections": [
-    { "point": [0,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "land", "swamp" ],
-    "city_distance": [3, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [1, 1],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
-  },{
-    "type": "overmap_special",
     "id": "Bee Hive",
+    "copy-from" : "Bee Hive",
     "overmaps": [
       { "point":[0,0,0], "overmap": "hive"},
       { "point":[0,1,0], "overmap": "hive"},
@@ -107,8 +65,6 @@
       { "point":[2,1,0], "overmap": "hive"},
       { "point":[2,2,0], "overmap": "hive"}
     ],
-    "locations": [ "forest" ],
-    "city_distance": [10, -1],
     "city_sizes": [4, 16],
     "occurrences": [0, 3],
     "rotate": true,
@@ -241,6 +197,7 @@
   },{
     "type": "overmap_special",
     "id": "Apartments_Con",
+    "copy-from" : "Apartments_Con",
     "overmaps": [
       { "point":[0,0,0], "overmap": "apartments_con_tower_NW_north"},
       { "point":[1,0,0], "overmap": "apartments_con_tower_NE_north"},
@@ -261,10 +218,8 @@
     ],
     "locations": [ "land" ],
     "city_distance": [0, 8],
-    "city_sizes": [4, 12],
     "occurrences": [0, 2],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Apartments_Con_wide",
@@ -302,6 +257,7 @@
   },{
     "type": "overmap_special",
     "id": "Triffid Grove",
+    "copy-from" : "Triffid Grove",
     "overmaps":
     [
       { "point":[0,0,0], "overmap": "triffid_grove"},
@@ -309,7 +265,6 @@
       { "point":[0,0,-2], "overmap": "triffid_roots"},
       { "point":[0,0,-3], "overmap": "triffid_finale"}
     ],
-    "locations": [ "forest" ],
     "city_distance": [1, -1],
     "city_sizes": [4, 16],
     "occurrences": [1, 4],
@@ -334,41 +289,28 @@
   },{
     "type": "overmap_special",
     "id": "Fungal Bloom",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "fungal_bloom"}
-    ],
+    "copy-from" : "Fungal Bloom",
     "locations": [ "land" ],
     "city_distance": [0, -1],
-    "city_sizes": [4, 12],
     "occurrences": [1, 2],
-    "rotate": false,
     "spawns": { "group": "GROUP_FUNGI", "population":[500,1000], "radius":[30,60] }
   },{
     "type": "overmap_special",
     "id": "Fungal Tower",
+    "copy-from" : "Fungal Tower",
     "overmaps":
     [
       { "point":[0,0,0], "overmap": "fungal_tower", "connect":"road", "existing": true}
     ],
     "locations": [ "land" ],
-    "city_distance": [5, -1],
-    "city_sizes": [4, 12],
     "occurrences": [1, 2],
-    "rotate": false,
     "spawns": { "group": "GROUP_FUNGI_TOWER", "population":[200,450], "radius":[10,20] }
   },{
     "type": "overmap_special",
     "id": "Fungal Flowers",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "fungal_flowers"}
-    ],
+    "copy-from" : "Fungal Flowers",
     "locations": [ "swamp" ],
     "city_distance": [8, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [1, 2],
-    "rotate": false,
     "spawns": { "group": "GROUP_FUNGI_FLOWERS", "population":[50,150], "radius":[15,35] }
   },{
     "type": "overmap_special",
@@ -385,26 +327,17 @@
   },{
     "type": "overmap_special",
     "id": "Anthill",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "anthill"}
-    ],
+    "copy-from" : "Anthill",
     "locations": [ "land", "swamp" ],
     "city_distance": [5, -1],
     "city_sizes": [4, 16],
     "occurrences": [0, 12],
-    "rotate": false,
     "spawns": { "group": "GROUP_ANT", "population":[700,2100], "radius":[20,45] }
   },{
     "type": "overmap_special",
     "id": "Spider Pit",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "spider_pit"},
-      { "point":[0,0,-1], "overmap": "spider_pit_under"}
-    ],
-    "locations": [ "forest" ],
+    "copy-from" : "Spider Pit",
     "city_distance": [0, -1],
-    "city_sizes": [4, 12],
     "occurrences": [2, 20],
     "rotate": true,
     "spawns": { "group":  "GROUP_SPIDER", "population":[20,60], "radius":[3,7] }
@@ -658,33 +591,20 @@
   },{
     "type": "overmap_special",
     "id": "Pond",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "pond_field"}
-    ],
-    "locations": [ "field" ],
+    "copy-from" : "Pond",
     "city_distance": [0, -1],
-    "occurrences": [3, 15],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [3, 15]
   },{
     "type": "overmap_special",
     "id": "basin",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "pond_forest"}
-    ],
-    "locations": [ "forest" ],
+    "copy-from" : "basin",
     "city_distance": [0, -1],
-    "occurrences": [3, 15],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [3, 15]
   },{
      "type": "overmap_special",
      "id": "bog",
-     "overmaps": [
-      { "point":[0,0,0], "overmap": "pond_swamp"}
-    ],
-    "locations": [ "swamp" ],
     "city_distance": [0, -1],
-    "occurrences": [0, 2],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 2]
   },{
     "type": "overmap_special",
     "id": "Plantation",

--- a/pk_overmap_freqloc.json
+++ b/pk_overmap_freqloc.json
@@ -2,16 +2,13 @@
   {
     "type": "overmap_special",
     "id": "Crater",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "crater"}
-    ],
-    "locations": [ "land", "swamp" ],
+    "copy-from" : "Crater",
     "city_distance": [0, -1],
-    "occurrences": [0, 12],
-    "flags": [ "BLOB", "CLASSIC" ]
+    "occurrences": [0, 12]
   },{
     "type": "overmap_special",
     "id": "Lake",
+    "copy-from" : "Lake",
     "overmaps": [
       { "point":[0,0,0], "overmap": "river_center"},
       { "point":[0,1,0], "overmap": "river_center"},
@@ -20,25 +17,16 @@
     ],
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [8, -1],
-    "city_sizes": [4, 12],
     "occurrences": [0, 2],
-    "rotate": true,
-    "flags": [ "BLOB", "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Mine Entrace",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "s_lot"},
-      { "point":[0,1,0], "overmap": "mine_entrance"}
-    ],
-    "connections": [
-      { "point": [0,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "Mine Entrace",
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [12, -1],
     "city_sizes": [4, 16],
-    "occurrences": [0, 3],
-    "rotate": false
+    "occurrences": [0, 3]
   },{
     "type": "overmap_special",
     "id": "Mine Entrace By Road",
@@ -57,27 +45,14 @@
   },{
     "type": "overmap_special",
     "id": "warehouse",
-    "overmaps": [ { "point":[0,0,0], "overmap": "warehouse_north"} ],
-    "connections": [
-      { "point": [0,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "land", "swamp" ],
-    "city_distance": [6, 20],
-    "city_sizes": [5, 12],
+    "copy-from" : "warehouse",
     "occurrences": [0, 5],
-    "rotate": true ,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Toxic Waste Dump",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "toxic_dump"}
-    ],
-    "locations": [ "wilderness", "swamp" ],
-    "city_distance": [15, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 4],
-    "flags": [ "CLASSIC" ]
+    "copy-from" : "Toxic Waste Dump",
+    "occurrences": [0, 4]
   },{
     "type": "overmap_special",
     "id": "Toxic Waste Dump_Swamp",
@@ -92,155 +67,59 @@
   },{
     "type": "overmap_special",
     "id": "sai",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "sai"}
-    ],
+    "copy-from" : "sai",
     "connections": [
       { "point": [0,-1,0], "terrain": "road", "existing": true }
     ],
     "locations": [ "land", "swamp" ],
     "city_distance": [0, 4],
-    "city_sizes": [2, 14],
     "occurrences": [0, 5],
     "rotate": true
   },{
     "type": "overmap_special",
     "id": "Hospital",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "hospital"},
-      { "point":[1,0,0], "overmap": "hospital_entrance"},
-      { "point":[2,0,0], "overmap": "hospital"},
-      { "point":[0,1,0], "overmap": "hospital"},
-      { "point":[1,1,0], "overmap": "hospital"},
-      { "point":[2,1,0], "overmap": "hospital"},
-      { "point":[0,2,0], "overmap": "hospital"},
-      { "point":[1,2,0], "overmap": "hospital"},
-      { "point":[2,2,0], "overmap": "hospital"}
-    ],
-    "connections": [
-      { "point": [1,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "wilderness" ],
+    "copy-from" : "Hospital",
     "city_distance": [0, 4],
-    "city_sizes": [4, 12],
     "occurrences": [1, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type" : "overmap_special",
     "id" : "Motel",
-    "overmaps" : [
-      { "point":[0,0,0], "overmap": "motel_entrance_north"},
-      { "point":[-1,0,0], "overmap": "motel_1_north"},
-      { "point":[-1,1,0], "overmap": "motel_2_north"},
-      { "point":[0,1,0], "overmap": "motel_3_north"}
-    ],
-    "connections" : [
-      { "point" : [0,-1,0], "terrain" : "road", "existing" : true }
-    ],
-    "locations" : [ "land", "swamp" ],
+    "copy-from" : "Motel",
     "city_distance" : [12, -1],
-    "city_sizes" : [1, 12],
-    "occurrences" : [0, 2],
-    "flags" : [ "CLASSIC" ]
+    "occurrences" : [0, 2]
   },{
     "type" : "overmap_special",
     "id" : "Gas Station",
-    "overmaps" : [
-      { "point":[0,0,0], "overmap": "s_gas_north" }
-    ],
-    "connections" : [
-      { "point" : [0,-1,0], "terrain" : "road", "existing" : true }
-    ],
+    "copy-from" : "Gas Station",
     "locations" : [ "land" ],
     "city_distance" : [12, -1],
-    "city_sizes" : [4, 12],
-    "occurrences" : [1, 4],
-    "flags" : [ "CLASSIC" ]
+    "occurrences" : [1, 4]
   },{
     "type": "overmap_special",
     "id": "Hazardous Waste Sarcophagus",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "haz_sar"},
-      { "point":[1,0,0], "overmap": "haz_sar_entrance"},
-      { "point":[0,1,0], "overmap": "haz_sar"},
-      { "point":[1,1,0], "overmap": "haz_sar"},
-      { "point":[0,0,-2], "overmap": "haz_sar_b1"},
-      { "point":[1,0,-2], "overmap": "haz_sar_entrance_b1"},
-      { "point":[0,1,-2], "overmap": "haz_sar_b1"},
-      { "point":[1,1,-2], "overmap": "haz_sar_b1"}
-    ],
-    "connections": [
-      { "point": [1,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness", "swamp" ],
-    "city_distance": [15, -1],
-    "city_sizes": [4, 12],
+    "copy-from" : "Hazardous Waste Sarcophagus",
     "occurrences": [0, 3]
   },{
     "type": "overmap_special",
     "id": "Cathedral",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "cathedral_1"},
-      { "point":[1,0,0], "overmap": "cathedral_1_entrance"},
-      { "point":[0,1,0], "overmap": "cathedral_1"},
-      { "point":[1,1,0], "overmap": "cathedral_1"},
-      { "point":[0,0,-1], "overmap": "cathedral_b"},
-      { "point":[1,0,-1], "overmap": "cathedral_b_entrance"},
-      { "point":[0,1,-1], "overmap": "cathedral_b"},
-      { "point":[1,1,-1], "overmap": "cathedral_b"}
-    ],
-    "connections": [
-      { "point": [0,-1,0], "terrain": "road" },
-      { "point": [1,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness" ],
+    "copy-from" : "Cathedral",
     "city_distance": [0, 8],
     "city_sizes": [4, 16],
     "occurrences": [0, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "farm_abandoned",
-    "overmaps": [
-      { "point":[1,0,0], "overmap": "car_corner_aban1_north"},
-      { "point":[0,0,0], "overmap": "cabin_aban1_north"},
-      { "point":[1,-1,0], "overmap": "barn_aban1_north"},
-      { "point":[0,-1,0], "overmap": "dirtplaza_aban1_north"},
-      { "point":[0,-2,0], "overmap": "dirtroad2_aban1_north"},
-      { "point":[0,-3,0], "overmap": "dirtroad2_aban1_north"},
-      { "point":[-1,-5,0], "overmap": "radio_tower"},
-      { "point":[0,-4,0], "overmap": "dirtroad1_aban1_north"},
-      { "point":[2,0,0], "overmap": "forest_aban1_north"},
-      { "point":[1,1,0], "overmap": "forest_aban1_north"},
-      { "point":[0,1,0], "overmap": "forest_aban1_north"},
-      { "point":[2,-1,0], "overmap": "forest_aban1_north"},
-      { "point":[-1,-1,0], "overmap": "forest_aban1_north"},
-      { "point":[-1,-2,0], "overmap": "forest_aban1_north"},
-      { "point":[-1,-3,0], "overmap": "forest_aban1_north"},
-      { "point":[-1,-4,0], "overmap": "forest_aban1_north"},
-      { "point":[1,-2,0], "overmap": "forest_aban1_north"},
-      { "point":[1,-3,0], "overmap": "forest_aban1_north"},
-      { "point":[1,-4,0], "overmap": "forest_aban1_north"}
-    ],
-    "connections": [
-      { "point": [-2,-5,0], "terrain": "road" },
-      { "point": [0,-5,0], "terrain": "road" }
-    ],
+    "copy-from" : "Cathedral",
     "locations": [ "field" ],
     "city_distance": [12, -1],
     "city_sizes": [4, 12],
-    "occurrences": [0, 1],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Evac Shelter",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "shelter"},
-      { "point":[0,0,-1], "overmap": "shelter_under"}
-    ],
+    "copy-from" : "Evac Shelter",
     "connections": [
       { "point": [0,-1,0], "terrain": "road", "existing": true }
     ],
@@ -248,8 +127,7 @@
     "city_distance": [4, 10],
     "city_sizes": [4, 16],
     "occurrences": [1, 10],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Evac Shelter Wilderness",
@@ -271,57 +149,25 @@
   },{
     "type": "overmap_special",
     "id": "Slime Pit",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "slimepit_down"}
-    ],
-    "locations": [ "land", "swamp" ],
+    "copy-from" : "Slime Pit",
     "city_distance": [0, -1],
-    "city_sizes": [4, 12],
     "occurrences": [0, 8],
     "rotate": true,
     "spawns": { "group": "GROUP_GOO", "population":[100,200], "radius":[5,15] }
   },{
     "type": "overmap_special",
     "id": "Home Improvement Superstore",
-    "overmaps": [
-      { "point":[0,1,0], "overmap": "hdwr_large_entrance"},
-      { "point":[-1,1,0], "overmap": "hdwr_large_SW"},
-      { "point":[-1,0,0], "overmap": "hdwr_large_NW"},
-      { "point":[0,0,0], "overmap": "hdwr_large_NE"},
-      { "point":[-1,-1,0], "overmap": "hdwr_large_backroom"},
-      { "point":[0,-1,0], "overmap": "hdwr_large_loadingbay"},
-      { "point":[1,2,0], "overmap": "s_lot"}
-    ],
-    "connections": [
-      { "point": [0,2,0], "terrain": "road" },
-      { "point": [-1,2,0], "terrain": "road" }
-    ],
+    "copy-from" : "Home Improvement Superstore",
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [0, 20],
     "city_sizes": [6, 20],
-    "occurrences": [0, 2],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 2]
   },{
     "type": "overmap_special",
     "id": "Public Works",
-    "overmaps": [
-      { "point": [0,2,0], "overmap": "road_end_north"},
-      { "point":[0,0,0], "overmap": "public_works_NW_north"},
-      { "point":[1,0,0], "overmap": "public_works_NE_north"},
-      { "point":[0,1,0], "overmap": "public_works_SW_north"},
-      { "point":[1,1,0], "overmap": "public_works_SE_north"}
-    ],
-    "connections" : [
-      { "point" : [0,2,0] }
-    ],
-    "locations": [ "wilderness", "swamp" ],
+    "copy-from" : "Public Works",
     "city_distance": [2, 12],
-    "city_sizes": [4, 12],
-    "occurrences": [1, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Public Works By Road",
@@ -344,6 +190,7 @@
   },{
     "type": "overmap_special",
     "id": "Mall",
+    "copy-from" : "Mall",
     "overmaps": [
       { "point":[0,0,0], "overmap": "mall_a_1_north"},
       { "point":[1,0,0], "overmap": "mall_a_2_north"},
@@ -441,29 +288,19 @@
     "city_distance": [1, -1],
     "city_sizes": [5, 12],
     "occurrences": [0, 1],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Apartments_Mod",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "apartments_mod_tower_NW_north" },
-      { "point":[1,0,0], "overmap": "apartments_mod_tower_NE_north" },
-      { "point":[0,1,0], "overmap": "apartments_mod_tower_SW_north" },
-      { "point":[1,1,0], "overmap": "apartments_mod_tower_SE_north" }
-    ],
-    "connections": [
-      { "point": [1,-1,0], "terrain": "road", "existing": true }
-    ],
+    "copy-from" : "Apartments_Mod",
     "locations": [ "land" ],
     "city_distance": [0, 2],
-    "city_sizes": [4, 12],
     "occurrences": [0, 4],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Necropolis",
+    "copy-from" : "Necropolis",
     "overmaps": [
       { "point":[0,0,0], "overmap": "necropolis_a_1_north"},
       { "point":[1,0,0], "overmap": "necropolis_a_2_north"},
@@ -801,7 +638,6 @@
       { "point": [-7,-5,-1], "overmap": "subway_station" },
       { "point":[-10,-7,0], "overmap": "radio_tower"},
       { "point":[4,-2,0], "overmap": "sai"}
-      
     ],
       "connections": [
         { "point": [-7,-6,-1], "terrain": "subway" },
@@ -821,37 +657,7 @@
   },{
     "type": "overmap_special",
     "id": "evac_center",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "evac_center_1_north"},
-      { "point":[1,0,0], "overmap": "evac_center_2_north"},
-      { "point":[2,0,0], "overmap": "evac_center_3_north"},
-      { "point":[3,0,0], "overmap": "evac_center_4_north"},
-      { "point":[4,0,0], "overmap": "evac_center_5_north"},
-      { "point":[0,1,0], "overmap": "evac_center_6_north"},
-      { "point":[1,1,0], "overmap": "evac_center_7_north"},
-      { "point":[2,1,0], "overmap": "evac_center_8_north"},
-      { "point":[3,1,0], "overmap": "evac_center_9_north"},
-      { "point":[4,1,0], "overmap": "evac_center_10_north"},
-      { "point":[0,2,0], "overmap": "evac_center_11_north"},
-      { "point":[1,2,0], "overmap": "evac_center_12_north"},
-      { "point":[2,2,0], "overmap": "evac_center_13_north"},
-      { "point":[3,2,0], "overmap": "evac_center_14_north"},
-      { "point":[4,2,0], "overmap": "evac_center_15_north"},
-      { "point":[0,3,0], "overmap": "evac_center_16_north"},
-      { "point":[1,3,0], "overmap": "evac_center_17_north"},
-      { "point":[2,3,0], "overmap": "evac_center_18_north"},
-      { "point":[3,3,0], "overmap": "evac_center_19_north"},
-      { "point":[4,3,0], "overmap": "evac_center_20_north"},
-      { "point":[0,4,0], "overmap": "evac_center_21_north"},
-      { "point":[1,4,0], "overmap": "evac_center_22_north"},
-      { "point":[2,4,0], "overmap": "evac_center_23_north"},
-      { "point":[3,4,0], "overmap": "evac_center_24_north"},
-      { "point":[4,4,0], "overmap": "evac_center_25_north"}
-    ],
-      "connections": [
-        { "point": [2,5,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness" ],
+    "copy-from" : "evac_center",
     "city_distance": [2, 12],
     "city_sizes": [4, 16],
     "occurrences": [1, 1],
@@ -859,26 +665,12 @@
   },{
     "type": "overmap_special",
     "id": "FEMA Camp",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "fema"},
-      { "point":[1,0,0], "overmap": "fema_entrance"},
-      { "point":[2,0,0], "overmap": "fema"},
-      { "point":[0,1,0], "overmap": "fema"},
-      { "point":[1,1,0], "overmap": "fema"},
-      { "point":[2,1,0], "overmap": "fema"},
-      { "point":[0,2,0], "overmap": "fema"},
-      { "point":[1,2,0], "overmap": "fema"},
-      { "point":[2,2,0], "overmap": "fema"}
-    ],
-      "connections": [
-        { "point": [1,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "FEMA Camp",
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [8, 30],
     "city_sizes": [4, 20],
     "occurrences": [0, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Megastore By Road",
@@ -909,6 +701,7 @@
   },{
     "type": "overmap_special",
     "id": "Megastore",
+    "copy-from" : "Megastore",
     "overmaps": [
       { "point":[0,-1,0], "overmap": "s_lot"},
       { "point":[1,-1,0], "overmap": "s_lot"},
@@ -929,48 +722,21 @@
     ],
     "locations": [ "land" ],
     "city_distance": [0, 12],
-    "city_sizes": [4, 12],
     "occurrences": [1, 2],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "School",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "school_3"},
-      { "point":[1,0,0], "overmap": "school_2"},
-      { "point":[2,0,0], "overmap": "school_1"},
-      { "point":[0,1,0], "overmap": "school_6"},
-      { "point":[1,1,0], "overmap": "school_5"},
-      { "point":[2,1,0], "overmap": "school_4"},
-      { "point":[0,2,0], "overmap": "school_9"},
-      { "point":[1,2,0], "overmap": "school_8"},
-      { "point":[2,2,0], "overmap": "school_7"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" },
-        { "point": [1,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "School",
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [0, 8],
     "city_sizes": [4, 16],
     "occurrences": [1, 2],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Strangle Temple",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "temple_stairs"},
-      { "point":[0,0,-1], "overmap": "temple_stairs"},
-      { "point":[0,0,-2], "overmap": "temple_stairs"},
-      { "point":[0,0,-3], "overmap": "temple_stairs"},
-      { "point":[0,0,-4], "overmap": "temple_stairs"},
-      { "point":[0,0,-5], "overmap": "temple_finale"}
-    ],
-    "locations": [ "forest", "swamp" ],
-    "city_distance": [20, -1],
-    "city_sizes": [4, 12],
+    "copy-from" : "Strangle Temple",
     "occurrences": [0, 2]
   },{
     "type": "overmap_special",
@@ -990,34 +756,24 @@
   },{
     "type": "overmap_special",
     "id": "bandit_cabin",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "bandit_cabin"}
-    ],
-      "connections": [
+    "copy-from" : "bandit_cabin",
+    "connections": [
         { "point": [1,0,0], "terrain": "road", "existing": true }
     ],
     "locations": [ "forest", "swamp" ],
     "city_distance": [15, -1],
     "city_sizes": [4, 16],
-    "occurrences": [0, 2],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 2]
   },{
     "type": "overmap_special",
     "id": "bandit_camp",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "bandit_camp_1"},
-      { "point":[1,0,0], "overmap": "bandit_camp_2"},
-      { "point":[0,1,0], "overmap": "bandit_camp_3"},
-      { "point":[1,1,0], "overmap": "bandit_camp_4"}
-    ],
-      "connections": [
+    "copy-from" : "bandit_camp",
+    "connections": [
         { "point": [-1,0,0], "terrain": "road", "existing": true }
     ],
-    "locations": [ "forest" ],
     "city_distance": [10, -1],
     "city_sizes": [4, 16],
-    "occurrences": [1, 3],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [1, 3]
   },{
     "type": "overmap_special",
     "id": "bandit_camp wilderness",
@@ -1035,35 +791,21 @@
   },{
     "type": "overmap_special",
     "id": "power_station_small",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "pwr_sub_s"}
-    ],
-      "connections": [
+    "copy-from" : "power_station_small",
+    "connections": [
         { "point": [-1,0,0], "terrain": "road", "existing": true }
     ],
     "locations": [ "land" ],
     "city_distance": [0, 20],
-    "city_sizes": [2, 14],
     "occurrences": [1, 6],
     "rotate": true,
     "spawns": { "group": "GROUP_SMALL_STATION", "population":[4, 10], "radius":[2, 5] }
   },{
     "type" : "overmap_special",
     "id" : "power_station_large",
-    "overmaps" : [
-      { "point":[0,1,0], "overmap": "pwr_large_entrance"},
-      { "point":[-1,1,0], "overmap": "pwr_large_2"},
-      { "point":[-1,0,0], "overmap": "pwr_large_3"},
-      { "point":[0,0,0], "overmap": "pwr_large_4"}
-    ],
-    "connections" : [
-      { "point" : [0,2,0], "terrain" : "road" }
-    ],
+    "copy-from" : "power_station_large",
     "locations" : [ "wilderness", "swamp" ],
     "city_distance" : [4, 20],
-    "city_sizes" : [4, 14],
-    "occurrences" : [1, 3],
-    "rotate" : false,
     "spawns" : { "group" : "GROUP_LARGE_STATION", "population":[4, 10], "radius":[3, 5] }
   },{
     "type" : "overmap_special",
@@ -1086,43 +828,19 @@
   },{
     "type": "overmap_special",
     "id": "football_field",
-    "overmaps": [
-      { "point":[-4,2,0], "overmap": "football_field_c1_north"},
-      { "point":[-3,2,0], "overmap": "football_field_c2_north"},
-      { "point":[-2,2,0], "overmap": "football_field_c3_north"},
-      { "point":[-1,2,0], "overmap": "football_field_c4_north"},
-      { "point":[0,2,0], "overmap": "football_field_c5_north"},
-      { "point":[-4,1,0], "overmap": "football_field_b1_north"},
-      { "point":[-3,1,0], "overmap": "football_field_b2_north"},
-      { "point":[-2,1,0], "overmap": "football_field_b3_north"},
-      { "point":[-1,1,0], "overmap": "football_field_b4_north"},
-      { "point":[0,1,0], "overmap": "football_field_b5_north"},
-      { "point":[-4,0,0], "overmap": "football_field_a1_north"},
-      { "point":[-3,0,0], "overmap": "football_field_a2_north"},
-      { "point":[-2,0,0], "overmap": "football_field_a3_north"},
-      { "point":[-1,0,0], "overmap": "football_field_a4_north"},
-      { "point":[0,0,0], "overmap": "football_field_a5_north"}
-    ],
-      "connections": [
+    "copy-from" : "football_field",
+    "connections": [
         { "point": [0,3,0], "terrain": "road", "existing": true }
     ],
     "locations": [ "field" ],
     "city_distance": [0, 6],
     "city_sizes": [4, 16],
     "occurrences": [0, 1],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Lab",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "lab_stairs"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness", "swamp" ],
+    "copy-from" : "Lab",
     "city_distance": [10, -1],
     "city_sizes": [8, 12],
     "occurrences": [2, 6],
@@ -1145,32 +863,17 @@
   },{
     "type": "overmap_special",
     "id": "Ice Lab",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "ice_lab_stairs"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness", "swamp" ],
+    "copy-from" : "Ice Lab",
     "city_distance": [10, -1],
-    "city_sizes": [4, 12],
     "occurrences": [1, 5],
     "rotate": true
   },{
     "type": "overmap_special",
     "id": "LMOE Shelter",
-    "overmaps":
-    [
-      { "point":[0,0,0], "overmap": "lmoe"},
-      { "point":[0,0,-1], "overmap": "lmoe_under"}
-    ],
-    "locations": [ "forest", "swamp" ],
+    "copy-from" : "LMOE Shelter",
     "city_distance": [0, -1],
-    "city_sizes": [4, 12],
     "occurrences": [1, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "LMOE Shelter_swamp",
@@ -1188,15 +891,8 @@
   },{
     "type": "overmap_special",
     "id": "Cabin",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "cabin"}
-    ],
-    "locations": [ "forest" ],
-    "city_distance": [20, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 4],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "copy-from" : "Cabin",
+    "occurrences": [0, 4]
   },{
     "type": "overmap_special",
     "id": "Cabin_swamp",
@@ -1212,6 +908,7 @@
   },{
     "type": "overmap_special",
     "id": "Sewage Treatment Plant",
+    "copy-from" : "Sewage Treatment Plant",
     "overmaps": [
       { "point":[0,0,0], "overmap": "s_lot"},
       { "point":[0,1,0], "overmap": "sewage_treatment"},
@@ -1232,10 +929,7 @@
     ],
     "locations": [ "land", "swamp" ],
     "city_distance": [12, 30],
-    "city_sizes": [4, 12],
-    "occurrences": [1, 3],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "occurrences": [1, 3]
   },{
     "type": "overmap_special",
     "id": "Sewage Treatment Plant By Road",
@@ -1266,16 +960,7 @@
   },{
     "type": "overmap_special",
     "id": "Military Bunker",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "bunker"},
-      { "point":[0,0,-1], "overmap": "bunker"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "wilderness", "swamp" ],
-    "city_distance": [4, -1],
-    "city_sizes": [2, 10],
+    "copy-from" : "Military Bunker",
     "occurrences": [0, 4],
     "rotate": true
   },{
@@ -1296,14 +981,8 @@
   },{
     "type": "overmap_special",
     "id": "Military Outpost",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "outpost"}
-    ],
-    "locations": [ "wilderness", "swamp"],
-    "city_distance": [4, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 7],
-    "rotate": false
+    "copy-from" : "Military Outpost",
+    "occurrences": [0, 7]
   },{
     "type": "overmap_special",
     "id": "Military Outpost_by_road",
@@ -1321,32 +1000,18 @@
   },{
     "type": "overmap_special",
     "id": "Missile Silo",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "silo"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "Missile Silo",
     "locations": [ "land", "swamp" ],
-    "city_distance": [30, -1],
-    "city_sizes": [4, 12],
     "occurrences": [0, 2],
     "rotate": true
   },{
     "type": "overmap_special",
     "id": "Radio Tower",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "radio_tower"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "Radio Tower",
     "locations": [ "wilderness" ],
     "city_distance": [8, -1],
-    "city_sizes": [4, 12],
     "occurrences": [1, 3],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Radio Tower Road",
@@ -1365,161 +1030,73 @@
   },{
     "type": "overmap_special",
     "id": "Mansion_Road",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "mansion"},
-      { "point":[1,0,0], "overmap": "mansion_entrance"},
-      { "point":[2,0,0], "overmap": "mansion"},
-      { "point":[0,1,0], "overmap": "mansion"},
-      { "point":[1,1,0], "overmap": "mansion"},
-      { "point":[2,1,0], "overmap": "mansion"},
-      { "point":[0,2,0], "overmap": "mansion"},
-      { "point":[1,2,0], "overmap": "mansion"},
-      { "point":[2,2,0], "overmap": "mansion"}
-    ],
-      "connections": [
-        { "point": [1,-1,0], "terrain": "road" }
-    ],
-    "locations": [ "wilderness", "swamp" ],
+    "copy-from" : "Mansion_Road",
     "city_distance": [0, -1],
-    "city_sizes": [4, 12],
     "occurrences": [0, 4],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Mansion_Wild",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "mansion"},
-      { "point":[1,0,0], "overmap": "mansion_entrance"},
-      { "point":[2,0,0], "overmap": "mansion"},
-      { "point":[0,1,0], "overmap": "mansion"},
-      { "point":[1,1,0], "overmap": "mansion"},
-      { "point":[2,1,0], "overmap": "mansion"},
-      { "point":[0,2,0], "overmap": "mansion"},
-      { "point":[1,2,0], "overmap": "mansion"},
-      { "point":[2,2,0], "overmap": "mansion"}
-    ],
-      "connections": [
-        { "point": [1,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "wilderness", "swamp" ],
-    "city_distance": [10, -1],
-    "city_sizes": [4, 12],
+    "copy-from" : "Mansion_Wild",
     "occurrences": [0, 2],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "campsite",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "campsite"}
-    ],
+    "copy-from" : "campsite",
     "locations": [ "forest", "swamp" ],
-    "city_distance": [15, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 5],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 5]
   },{
     "type": "overmap_special",
     "id": "campsite_cabin_incomplete",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "campsite_cabin_incomplete"}
-    ],
-    "locations": [ "forest" ],
-    "city_distance": [20, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 4],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "copy-from" : "campsite_cabin_incomplete",
+    "occurrences": [0, 4]
   },{
     "type": "overmap_special",
     "id": "campsite_a",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "campsite_a"}
-    ],
+    "copy-from" : "campsite_a",
     "locations": [ "forest", "swamp" ],
-    "city_distance": [10, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 5],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 5]
   },{
     "type": "overmap_special",
     "id": "campsite_field_biker",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "campsite_field_biker"}
-    ],
-      "connections": [
+    "copy-from" : "campsite_field_biker",
+    "connections": [
         { "point": [0,-1,0], "terrain": "road", "existing": true }
     ],
-    "locations": [ "field" ],
-    "city_distance": [10, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 3],
-    "rotate": false,
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 3]
   },{
     "type": "overmap_special",
     "id": "campsite_field_biker_destroyed",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "campsite_field_biker_destroyed"}
-    ],
-      "connections": [
+    "copy-from" : "campsite_field_biker_destroyed",
+    "connections": [
         { "point": [0,-1,0], "terrain": "road", "existing": true }
     ],
-    "locations": [ "field" ],
-    "city_distance": [10, -1],
-    "city_sizes": [4, 12],
-    "occurrences": [0, 7],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [0, 7]
   },{
     "type": "overmap_special",
     "id": "rest_stop",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "roadstop_north"}
-    ],
-      "connections": [
+    "copy-from" : "rest_stop",
+    "connections": [
         { "point": [0,-1,0], "terrain": "road", "existing": true }
     ],
-    "locations": [ "land" ],
-    "city_distance": [10, 200],
     "city_sizes": [4, 12],
     "occurrences": [ 0 , 2 ],
-    "rotate": true,
-    "extras": "build",
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "roadstop_a",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "roadstop_a_north"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "land" ],
-    "city_distance": [10, 200],
+    "copy-from" : "roadstop_a",
     "city_sizes": [4, 12],
     "occurrences": [ 0 , 2 ],
-    "rotate": true,
-    "extras": "build",
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "roadstop_b",
-    "overmaps": [
-      { "point":[0,0,0], "overmap": "roadstop_b_north"}
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road", "existing": true }
-    ],
-    "locations": [ "land" ],
-    "city_distance": [10, 200],
+    "copy-from" : "roadstop_b",
     "city_sizes": [4, 12],
     "occurrences": [ 0, 2 ],
-    "rotate": true,
-    "extras": "build",
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Pump Station Terminal",
@@ -1544,6 +1121,7 @@
   },{
     "type": "overmap_special",
     "id": "pump_station",
+    "copy-from" : "pump_station",
     "overmaps": [
       { "point": [0,0,0],   "overmap": "pump_station_1_north" },
       { "point": [0,1,0],   "overmap": "pump_station_2_north" },
@@ -1558,32 +1136,19 @@
     ],
     "locations": [ "land", "swamp" ],
     "city_distance": [0,-1],
-    "city_sizes": [4,12],
     "occurrences": [ 0, 2 ],
-    "rotate": true,
-    "flags": ["CLASSIC"]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "garage_gas",
-    "overmaps": [
-      { "point": [0,0,0], "overmap": "garage_gas_1_north" },
-      { "point": [1,0,0], "overmap": "garage_gas_2_north" },
-      { "point": [2,0,0], "overmap": "garage_gas_3_north" }
-    ],
-      "connections": [
-        { "point": [0,-1,0], "terrain": "road" },
-        { "point": [1,-1,0], "terrain": "road" },
-        { "point": [2,-1,0], "terrain": "road" }
-    ],
+    "copy-from" : "garage_gas",
     "locations": [ "land" ],
     "city_distance": [0,4],
-    "city_sizes": [4,12],
-    "occurrences": [ 0, 4 ],
-    "rotate": true,
-    "flags": ["CLASSIC"]
+    "rotate": true
   },{
     "type": "overmap_special",
     "id": "Office_Tower_2.0",
+    "copy-from" : "Office_Tower_2.0",
     "overmaps": [
       { "point":[-2,0,0], "overmap": "office_tower_2_a1_north"},
       { "point":[-1,0,0], "overmap": "office_tower_2_a2_north"},
@@ -1600,9 +1165,7 @@
     ],
     "locations": [ "land" ],
     "city_distance": [0, 8],
-    "city_sizes": [6, 12],
     "occurrences": [ 1, 4 ],
-    "rotate": true,
-    "flags": [ "CLASSIC" ]
+    "rotate": true
   }
 ]


### PR DESCRIPTION
Removes swamp shack overmap special, as no difference was observed between mainline and the mod. I would assume that swamp shacks were ported into the main game from PK Reblance?

Additionally removed the override for prisons, as the only evident difference was different handling for how connection to a road was handled. Please correct me if the different handling has any change in net result, but it appears as though no difference resulted. If so, my apologies.

Likewise, overrides for hospitals, motels, hazardous waste sarcophagi, cathedrals, schools, and refugee centers have had the changes to overmaps and connections removed, but other overriding changes retained. Will undo this change if you request it, as I am uncertain what the change in connection handling is for.

For most other overriding overmap specials, implemented use of `copy-from` to reduce edits to only what was different, reducing the risk of desync with mainline and reducing the odds of any future mods interacting with the chances.

Handling of farms has been left unchanged for the moment as I am uncertain of desired handling. Mainline farms now have a connection to roads, whereas you make use of separate isolated farms (overriding) and the addition of farms with roads. Suggestions as to proper handling of this case would be desired.

Use of copy-from ensures pending changes to cathedrals, and prisons will not require any update to avoid desync with mainline, but farms will still be a problem in the future.

My apologies if I missed anything significant.