### PR TITLE
Changes itemgroup to cite spear_pipe

### DIFF
--- a/pk_itemlist_new.json
+++ b/pk_itemlist_new.json
@@ -202,7 +202,7 @@
     ["q_staff", 6],
     ["spear_wood", 6],
     ["spear_forked", 6],
-    ["spear_steel", 6],
+    ["spear_pipe", 6],
     ["spear_copper", 5],
     ["sword_crude", 5],
     ["homewrecker", 5],


### PR DESCRIPTION
This pull request changes the sole usage of `spear_steel` to `spear_pipe`, in one item group. Reasoning is that pipe spears have been added, to represent the older makeshift welded steel spear, while the ID for steel spears is now used for a proper forged weapon.

Relevent pull request is: https://github.com/CleverRaven/Cataclysm-DDA/pull/21170