### PR TITLE
Correct implenentation of spear changes

### DIFF
--- a/items/melee.json
+++ b/items/melee.json
@@ -1161,8 +1161,8 @@
   },
   {
     "type":"GENERIC",
-    "id" : "spear_steel",
-    "name" : "steel spear",
+    "id" : "spear_pipe",
+    "name" : "pipe spear",
     "description" : "A stout metal pole with a sharp point.",
     "weight" : 1398,
     "to_hit" : 1,

--- a/spawns/pk_itemlist_new.json
+++ b/spawns/pk_itemlist_new.json
@@ -211,7 +211,7 @@
       [ "q_staff", 6 ],
       [ "spear_wood", 6 ],
       [ "spear_forked", 6 ],
-      [ "spear_steel", 6 ],
+      [ "spear_pipe", 6 ],
       [ "vortex_stone", 6 ],
       [ "spear_copper", 5 ],
       [ "sword_crude", 5 ],


### PR DESCRIPTION
Correct attempt this time, my apologies for that.

This pull request changes the usage of `spear_steel` to `spear_pipe`. Reasoning is that pipe spears have been added, to represent the older makeshift welded steel spear, while the ID for steel spears is now used for a proper forged weapon.

As I do not know in full what you prefer with respect to rebalancing spears, I will leave any desired changes to the new steel spear to you.

Relevent pull request is: https://github.com/CleverRaven/Cataclysm-DDA/pull/21170