### PR TITLE
Missing json attributes in regional_settings.json

### DIFF
--- a/pk_regional_settings.json
+++ b/pk_regional_settings.json
@@ -131,15 +131,25 @@
         "type": "town",
         "shop_radius": 80,              "//": "determine radial frequency of shops / parks / houses for towns. tldr: less means more",
         "park_radius": 130,             "//": "this is not a cut and dry % but rather an inverse voodoo number; rng(0,99) > VOODOO * distance / citysize;",
+        "house_basement_chance": 5, "//": "one_in(n) chance a house has a basement",
         "parks": {                  "//": "weighted list for park overmap terrains",
           "park": 4,
-          "pool": 1
+          "pool": 1,
+          "skate_park": 1,
+          "small_wooded_trail": 3,
+          "pavilion": 2,
+          "cemetery_small": 2,
+          "Pond": 2
         },
         "houses": {
           "house_two_story_basement": 5,
           "house": 1000,
           "house_prepper": 30,
           "house_base": 333
+        },
+        "basements": {
+          "basement": 1000,
+          "basement_bionic": 50
         },
         "shops": {                  "//": "weighted list of oterrains for commercial zoning",
           "s_gas": 5,


### PR DESCRIPTION
Hello,

The newest version of catacylsm (https://github.com/CleverRaven/Cataclysm-DDA/commit/9d29bfe691387c7273c41b451e081c5c9b5d3b1a) requires the attributes "house_basement_chance" and "basements" in regional_settings.json. Without these attributes the game world does not load. I copied the default attributes from the base game.

Regards,
Sven